### PR TITLE
Fix node name in config.yaml

### DIFF
--- a/config/client.yaml
+++ b/config/client.yaml
@@ -1,4 +1,4 @@
-/vrpn_mocap/client_node:
+/vrpn_mocap/vrpn_mocap_client_node:
   ros__parameters:
     server: localhost
     port: 3883


### PR DESCRIPTION
In the launch file, the node is named "vrpn_mocap_client_node" not "client_node".
Therefore, the values in config.yaml will have no effect, as the node name is "client_node" instead of "vrpn_mocap_client_node".